### PR TITLE
Add Home-ota administration/management tool

### DIFF
--- a/content/implementations.md
+++ b/content/implementations.md
@@ -68,7 +68,7 @@ Administrative tools usually allow you to detect, list and interact with Homie d
 | Name         | Homie | Download| Implementation notes   |
 |--------------|----------|---------------|--------------------------------------------|
 | Hodmin      | 2.0      | [Website](https://github.com/rttools/hodmin) |  |
-| Homie-ota    |3.0      | [GitHub](https://github.com/jpmens/homie-ota) | |
+| Homie-ota    |3.0 + Custom OTA | [GitHub](https://github.com/jpmens/homie-ota) | OTA Server for devices running the homie-esp8266 firmware |
 
 
 ## Home automation

--- a/content/implementations.md
+++ b/content/implementations.md
@@ -68,6 +68,7 @@ Administrative tools usually allow you to detect, list and interact with Homie d
 | Name         | Homie | Download| Implementation notes   |
 |--------------|----------|---------------|--------------------------------------------|
 | Hodmin      | 2.0      | [Website](https://github.com/rttools/hodmin) |  |
+| Homie-ota    |3.0      | [GitHub](https://github.com/jpmens/homie-ota) | |
 
 
 ## Home automation


### PR DESCRIPTION
Add JP Mens'  Homie-ota tool.  

It provides an OTA server for Homie devices as well as a simple inventory which can be useful to keep track of Homie devices. Homie-ota also enables you to trigger an OTA update (over MQTT, using the Homie convention) from within its inventory. New firmware can be uploaded to homie-ota which detects firmware name (fwname) and version (fwversion) from the uploaded binary blob.