### PR TITLE
Add links to Rust homie-controller crate, and mijia-homie project

### DIFF
--- a/content/implementations.md
+++ b/content/implementations.md
@@ -69,6 +69,7 @@ A library can be included in your own project to act as a Controller for Homie d
 |--------------|----------|---------------|-----------------------------------------------------|
 | Homie-Device | Node JS  | 3.0           | [npmjs](https://www.npmjs.com/package/homie-device) |
 | homie-cpp    | C++      | 3.0           | [GitHub](https://github.com/Thalhammer/homie-cpp)   |
+| homie-controller | Rust | 4.0.0         | [crates.io](https://crates.io/crates/homie-controller) |
 
 
 ## Administration

--- a/content/implementations.md
+++ b/content/implementations.md
@@ -56,6 +56,7 @@ A software application that speaks MQTT/Homie and acts as a Homie Device.
 | MBMD         | Go       | 4.0           | [GitHub](https://github.com/volkszaehler/mbmd)     | A Linux daemon to fetch and publish data from ModBus devices like power meters and grid inverters|
 |Somecomfort-Home | Python | 4.0          | [GitHub](https://github.com/mjcumming/Somecomfort-Homie) | Homie implementation for Honeywell Total Comfort Thermostats using somecomefort|
 |ISY-Home-Bridge | Python | 4.0           | [GitHub](https://github.com/mjcumming/ISY-Homie_Bridge) | Homie implementation for Universal Devices ISY994 controller|
+| mijia-homie  | Rust     | 4.0           | [GitHub](https://github.com/alsuren/mijia-homie)   | A Linux daemon to fetch and publish data from Xiaomi Mijia v2 Bluetooth temperature and humidity sensors. |
 
 # Controller
 


### PR DESCRIPTION
`homie-controller` is the controller counterpart to the `homie-device` crate I added previously, and `mijia-homie` uses `homie-device` to publish temperature and humidity readings from a set of Xiaomi Mijia BLE sensors.